### PR TITLE
Add stubs for CouchbaseMetaDoc and CouchbaseExcpetion

### DIFF
--- a/genphpfile.sh
+++ b/genphpfile.sh
@@ -18,6 +18,8 @@ add_file "CouchbaseCluster.class.php"
 add_file "CouchbaseClusterManager.class.php"
 add_file "CouchbaseBucket.class.php"
 add_file "CouchbaseBucketManager.class.php"
+add_file "CouchbaseException.class.php"
+add_file "CouchbaseMetaDoc.class.php"
 
 echo "};" >> phpstubstr.h
 echo "Generated phpstubstr.h"

--- a/phpstubstr.h
+++ b/phpstubstr.h
@@ -1196,7 +1196,7 @@ pcbc_stub_data PCBC_PHP_CODESTR[] = {
 "     *\n" \
 "     * @param string|array $ids\n" \
 "     * @param array $options lock\n" \
-"     * @return mixed\n" \
+"     * @return CouchbaseMetaDoc\n" \
 "     */\n" \
 "    public function get($ids, $options = array()) {\n" \
 "        return $this->me->get($ids, $options);\n" \
@@ -1208,7 +1208,7 @@ pcbc_stub_data PCBC_PHP_CODESTR[] = {
 "     * @param string $id\n" \
 "     * @param integer $expiry\n" \
 "     * @param array $options\n" \
-"     * @return mixed\n" \
+"     * @return CouchbaseMetaDoc\n" \
 "     */\n" \
 "    public function getAndTouch($id, $expiry, $options = array()) {\n" \
 "        $options['expiry'] = $expiry;\n" \
@@ -1221,7 +1221,7 @@ pcbc_stub_data PCBC_PHP_CODESTR[] = {
 "     * @param string $id\n" \
 "     * @param integer $lockTime\n" \
 "     * @param array $options\n" \
-"     * @return mixed\n" \
+"     * @return CouchbaseMetaDoc\n" \
 "     */\n" \
 "    public function getAndLock($id, $lockTime, $options = array()) {\n" \
 "        $options['lockTime'] = $lockTime;\n" \
@@ -1233,7 +1233,7 @@ pcbc_stub_data PCBC_PHP_CODESTR[] = {
 "     *\n" \
 "     * @param string $id\n" \
 "     * @param array $options\n" \
-"     * @return mixed\n" \
+"     * @return CouchbaseMetaDoc\n" \
 "     */\n" \
 "    public function getFromReplica($id, $options = array()) {\n" \
 "        return $this->me->getFromReplica($id, $options);\n" \
@@ -1256,7 +1256,7 @@ pcbc_stub_data PCBC_PHP_CODESTR[] = {
 "     * Unlocks a key previous locked with a call to get().\n" \
 "     * @param string|array $ids\n" \
 "     * @param array $options cas\n" \
-"     * @return mixed\n" \
+"     * @return CouchbaseMetaDoc\n" \
 "     */\n" \
 "    public function unlock($ids, $options = array()) {\n" \
 "        return $this->me->unlock($ids, $options);\n" \
@@ -1380,6 +1380,7 @@ pcbc_stub_data PCBC_PHP_CODESTR[] = {
 "        if (is_array($res)) {\n" \
 "            // Build list of keys to check\n" \
 "            $chks = array();\n" \
+"            /** @var CouchbaseMetaDoc $result */\n" \
 "            foreach ($res as $key => $result) {\n" \
 "                if (!$result->error) {\n" \
 "                    $chks[$key] = array(\n" \
@@ -1403,6 +1404,7 @@ pcbc_stub_data PCBC_PHP_CODESTR[] = {
 "\n" \
 "            return $res;\n" \
 "        } else {\n" \
+"            /** @var CouchbaseMetaDoc $res */\n" \
 "            if ($res->error) {\n" \
 "                return $res;\n" \
 "            }\n" \
@@ -1618,4 +1620,29 @@ pcbc_stub_data PCBC_PHP_CODESTR[] = {
 "    }\n" \
 "} \n" \
 ""},
+{"[CouchbaseNative]/CouchbaseException.class.php","\n" \
+"/**\n" \
+" * Custom CouchbaseException stub\n" \
+" *\n" \
+" * @package Couchbase\n" \
+" */\n" \
+"class CouchbaseException extends Exception\n" \
+"{}\n" \
+""},
+{"[CouchbaseNative]/CouchbaseMetaDoc.class.php","\n" \
+"\n" \
+"/**\n" \
+" * Class CouchbaseMetaDoc\n" \
+" * This class has no methods, but is used by CouchbaseBucket\n" \
+" * Represents a couchbase document & meta\n" \
+" *\n" \
+" * @package Couchbase\n" \
+" */\n" \
+"class CouchbaseMetaDoc\n" \
+"{\n" \
+"    public $error = null;\n" \
+"    public $value = null;\n" \
+"    public $flags = null;\n" \
+"    public $case = null;\n" \
+"}\n" \""},
 };

--- a/stub/CouchbaseBucket.class.php
+++ b/stub/CouchbaseBucket.class.php
@@ -190,7 +190,7 @@ class CouchbaseBucket {
      *
      * @param string|array $ids
      * @param array $options lock
-     * @return mixed
+     * @return CouchbaseMetaDoc
      */
     public function get($ids, $options = array()) {
         return $this->me->get($ids, $options);
@@ -202,7 +202,7 @@ class CouchbaseBucket {
      * @param string $id
      * @param integer $expiry
      * @param array $options
-     * @return mixed
+     * @return CouchbaseMetaDoc
      */
     public function getAndTouch($id, $expiry, $options = array()) {
         $options['expiry'] = $expiry;
@@ -215,7 +215,7 @@ class CouchbaseBucket {
      * @param string $id
      * @param integer $lockTime
      * @param array $options
-     * @return mixed
+     * @return CouchbaseMetaDoc
      */
     public function getAndLock($id, $lockTime, $options = array()) {
         $options['lockTime'] = $lockTime;
@@ -227,7 +227,7 @@ class CouchbaseBucket {
      *
      * @param string $id
      * @param array $options
-     * @return mixed
+     * @return CouchbaseMetaDoc
      */
     public function getFromReplica($id, $options = array()) {
         return $this->me->getFromReplica($id, $options);
@@ -250,7 +250,7 @@ class CouchbaseBucket {
      * Unlocks a key previous locked with a call to get().
      * @param string|array $ids
      * @param array $options cas
-     * @return mixed
+     * @return CouchbaseMetaDoc
      */
     public function unlock($ids, $options = array()) {
         return $this->me->unlock($ids, $options);
@@ -374,6 +374,7 @@ class CouchbaseBucket {
         if (is_array($res)) {
             // Build list of keys to check
             $chks = array();
+            /** @var CouchbaseMetaDoc $result */
             foreach ($res as $key => $result) {
                 if (!$result->error) {
                     $chks[$key] = array(
@@ -397,6 +398,7 @@ class CouchbaseBucket {
 
             return $res;
         } else {
+            /** @var CouchbaseMetaDoc $res */
             if ($res->error) {
                 return $res;
             }

--- a/stub/CouchbaseException.class.php
+++ b/stub/CouchbaseException.class.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Custom CouchbaseException stub
+ *
+ * @package Couchbase
+ */
+class CouchbaseException extends Exception
+{}

--- a/stub/CouchbaseMetaDoc.class.php
+++ b/stub/CouchbaseMetaDoc.class.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Class CouchbaseMetaDoc
+ * This class has no methods, but is used by CouchbaseBucket
+ * Represents a couchbase document & meta
+ *
+ * @package Couchbase
+ */
+class CouchbaseMetaDoc
+{
+    public $error = null;
+    public $value = null;
+    public $flags = null;
+    public $case = null;
+}


### PR DESCRIPTION
Based on metadoc.c and exception.c, It'd make sense to add the PHP stubs for these classes. If only to prevent the IDE from complaining when it encounters code like:

``` php
function getObjectFromDoc(\CouchbaseMetaDoc $doc)
{
    return json_decode($doc->value);
}
try {
    $document = $bucket->get($id);
    $val = getObjectFromDoc($document);
} catch (\CouchbaseException $e) {
    //do stuff
}
```
