### PR TITLE
Destruct the error when you are done with it

### DIFF
--- a/bucket.c
+++ b/bucket.c
@@ -61,6 +61,7 @@ void bopcookie_error(const bopcookie *cookie, bucket_object *data, zval *doc,
 	zval *zerror = create_lcb_exception(error TSRMLS_CC);
 	if (Z_TYPE_P(cookie->retval) == IS_ARRAY) {
 		metadoc_from_error(doc, zerror TSRMLS_CC);
+		zval_ptr_dtor(&zerror);
 	} else {
 		data->error = zerror;
 	}


### PR DESCRIPTION
When a remove throws an exception (for example when the key is not found) then that exception will never be cleared and memory will be leaked. Destroying the error object after we gave it to the meta object will fix this.

This php script will show you the memory usage. Try it with and without this change :)

``` php
<?php

error_reporting(E_ALL);
ini_set('display_errors', true);

// Ignore me i am here to make the memory usage human readable
function convert($size)
{
    $unit=array('b','kb','mb','gb','tb','pb');
    return @round($size/pow(1024,($i=floor(log($size,1024)))),2).' '.$unit[$i];
}

$cluster = new \CouchbaseCluster('localhost:8091');
$bucket = $cluster->openBucket('bucket_name');

// Remove a lot of unknown ids batch style (which puts the exception in the meta doc)
for ($i = 0; $i < 10000; $i++) {
    $response = $bucket->remove(['unknown_1_' . $i, 'unknown_2_' . $i]);
    // Show the response only once (to make sure the error document is present)
    if ($i === 0) {
        var_dump($response);
    }
}

echo PHP_EOL;
echo PHP_EOL;

// Now do a lot of single deletes (which throws the exception)
for ($i = 0; $i < 10000; $i++) {
    try {
        $bucket->remove('unknown_3_' . $i);
    } catch (\Exception $e) {
        // Show the response only once (to make sure the error document is present)
        if ($i === 0) {
            var_dump($e->getMessage());
        }
    }
}

echo PHP_EOL;
echo PHP_EOL;
echo convert(memory_get_usage(true));
```
