### PR TITLE
Url encode values which are used in the query for views

### DIFF
--- a/phpstubstr.h
+++ b/phpstubstr.h
@@ -588,7 +588,7 @@ pcbc_stub_data PCBC_PHP_CODESTR[] = {
 "        $path = '/_design/' . $this->ddoc . '/' . $type . '/' . $this->name;\n" \
 "        $args = array();\n" \
 "        foreach ($this->options as $option => $value) {\n" \
-"            array_push($args, $option . '=' . $value);\n" \
+"            array_push($args, $option . '=' . urlencode($value));\n" \
 "        }\n" \
 "        $path .= '?' . implode('&', $args);\n" \
 "        return $path;\n" \

--- a/phpstubstr.h
+++ b/phpstubstr.h
@@ -586,11 +586,7 @@ pcbc_stub_data PCBC_PHP_CODESTR[] = {
 "     */\n" \
 "    public function _toString($type) {\n" \
 "        $path = '/_design/' . $this->ddoc . '/' . $type . '/' . $this->name;\n" \
-"        $args = array();\n" \
-"        foreach ($this->options as $option => $value) {\n" \
-"            array_push($args, $option . '=' . urlencode($value));\n" \
-"        }\n" \
-"        $path .= '?' . implode('&', $args);\n" \
+"        $path .= '?' . http_build_query($this->options);\n" \
 "        return $path;\n" \
 "    }\n" \
 "};\n" \

--- a/phpstubstr.h
+++ b/phpstubstr.h
@@ -1354,8 +1354,14 @@ pcbc_stub_data PCBC_PHP_CODESTR[] = {
 "        $path = $queryObj->toString();\n" \
 "        $res = $this->me->http_request(1, 1, $path, NULL, 1);\n" \
 "        $out = json_decode($res, $json_asarray);\n" \
-"        if (isset($out['error'])) {\n" \
-"            throw new CouchbaseException($out['error'] . ': ' . $out['reason']);\n" \
+"        if ($json_asarray) {\n" \
+"            if (isset($out['error'])) {\n" \
+"                throw new CouchbaseException($out['error'] . ': ' . $out['reason']);\n" \
+"            }\n" \
+"        } else {\n" \
+"            if (isset($out->error)) {\n" \
+"                throw new CouchbaseException($out->error . ': ' . $out->reason);\n" \
+"            }\n" \
 "        }\n" \
 "        return $out;\n" \
 "    }\n" \

--- a/stub/CouchbaseBucket.class.php
+++ b/stub/CouchbaseBucket.class.php
@@ -281,8 +281,14 @@ class CouchbaseBucket {
         $path = $queryObj->toString();
         $res = $this->me->http_request(1, 1, $path, NULL, 1);
         $out = json_decode($res, $json_asarray);
-        if (isset($out['error'])) {
-            throw new CouchbaseException($out['error'] . ': ' . $out['reason']);
+        if ($json_asarray) {
+            if (isset($out['error'])) {
+                throw new CouchbaseException($out['error'] . ': ' . $out['reason']);
+            }
+        } else {
+            if (isset($out->error)) {
+                throw new CouchbaseException($out->error . ': ' . $out->reason);
+            }
         }
         return $out;
     }

--- a/stub/CouchbaseViewQuery.class.php
+++ b/stub/CouchbaseViewQuery.class.php
@@ -133,11 +133,7 @@ class CouchbaseViewQuery {
      */
     public function _toString($type) {
         $path = '/_design/' . $this->ddoc . '/' . $type . '/' . $this->name;
-        $args = array();
-        foreach ($this->options as $option => $value) {
-            array_push($args, $option . '=' . urlencode($value));
-        }
-        $path .= '?' . implode('&', $args);
+        $path .= '?' . http_build_query($this->options);
         return $path;
     }
 };

--- a/stub/CouchbaseViewQuery.class.php
+++ b/stub/CouchbaseViewQuery.class.php
@@ -135,7 +135,7 @@ class CouchbaseViewQuery {
         $path = '/_design/' . $this->ddoc . '/' . $type . '/' . $this->name;
         $args = array();
         foreach ($this->options as $option => $value) {
-            array_push($args, $option . '=' . $value);
+            array_push($args, $option . '=' . urlencode($value));
         }
         $path .= '?' . implode('&', $args);
         return $path;


### PR DESCRIPTION
Lets say I want to query a view using this code:

``` php
$key = 'some_key';

$query = \CouchbaseViewQuery::form('my_document', 'view_name', array(
    'key' => $key,
    'limit' => 1,
));
$bucket->query($query);
```

This will work without problem. Now, if I change `$key` to `'some&key'`, I get the following error:

``` json
{
    "error": "bad_request",
    "reason": "invalid UTF-8 JSON: {{error,insufficient_data},\"\\\"some\"}"
}
```

This is caused by the query parameter values which are not urlencoded. My PR fixes that.
