### PR TITLE
CouchbaseBucket::query return now a CouchbaseResult which implements Iterator

### DIFF
--- a/genphpfile.sh
+++ b/genphpfile.sh
@@ -18,6 +18,7 @@ add_file "CouchbaseCluster.class.php"
 add_file "CouchbaseClusterManager.class.php"
 add_file "CouchbaseBucket.class.php"
 add_file "CouchbaseBucketManager.class.php"
+add_file "CouchbaseResult.class.php"
 
 echo "};" >> phpstubstr.h
 echo "Generated phpstubstr.h"

--- a/phpstubstr.h
+++ b/phpstubstr.h
@@ -1207,6 +1207,7 @@ pcbc_stub_data PCBC_PHP_CODESTR[] = {
 "            $this->me->upsert($ids, $val, $options));\n" \
 "    }\n" \
 "\n" \
+"\n" \
 "    /**\n" \
 "     * Replaces a document.\n" \
 "     *\n" \
@@ -1219,7 +1220,7 @@ pcbc_stub_data PCBC_PHP_CODESTR[] = {
 "        return $this->_endure($ids, $options,\n" \
 "            $this->me->replace($ids, $val, $options));\n" \
 "    }\n" \
-"    \n" \
+"\n" \
 "    /**\n" \
 "     * Appends content to a document.\n" \
 "     *\n" \
@@ -1232,7 +1233,7 @@ pcbc_stub_data PCBC_PHP_CODESTR[] = {
 "        return $this->_endure($ids, $options,\n" \
 "            $this->me->append($ids, $val, $options));\n" \
 "    }\n" \
-"    \n" \
+"\n" \
 "    /**\n" \
 "     * Prepends content to a document.\n" \
 "     *\n" \
@@ -1365,7 +1366,7 @@ pcbc_stub_data PCBC_PHP_CODESTR[] = {
 "        }\n" \
 "        return $out;\n" \
 "    }\n" \
-"    \n" \
+"\n" \
 "    /**\n" \
 "     * Performs a N1QL query.\n" \
 "     *\n" \
@@ -1384,7 +1385,7 @@ pcbc_stub_data PCBC_PHP_CODESTR[] = {
 "        }\n" \
 "        $dataStr = json_encode($data, true);\n" \
 "        $dataOut = $this->me->n1ql_request($dataStr, $queryObj->adhoc);\n" \
-"        \n" \
+"\n" \
 "        $meta = json_decode($dataOut['meta'], true);\n" \
 "        if (isset($meta['errors']) && count($meta['errors']) > 0) {\n" \
 "            $err = $meta['errors'][0];\n" \
@@ -1392,27 +1393,27 @@ pcbc_stub_data PCBC_PHP_CODESTR[] = {
 "            $ex->qCode = $err['code'];\n" \
 "            throw $ex;\n" \
 "        }\n" \
-"        \n" \
+"\n" \
 "        $rows = array();\n" \
 "        foreach ($dataOut['results'] as $row) {\n" \
 "            $rows[] = json_decode($row, $json_asarray);\n" \
 "        }\n" \
 "        return $rows;\n" \
 "    }\n" \
-"    \n" \
+"\n" \
 "    /**\n" \
 "     * Performs a query (either ViewQuery or N1qlQuery).\n" \
 "     *\n" \
 "     * @param CouchbaseQuery $query\n" \
-"     * @return mixed\n" \
+"     * @return CouchbaseResult\n" \
 "     * @throws CouchbaseException\n" \
 "     */\n" \
 "    public function query($query, $params = null, $json_asarray = false) {\n" \
 "        if ($query instanceof _CouchbaseDefaultViewQuery ||\n" \
 "            $query instanceof _CouchbaseSpatialViewQuery) {\n" \
-"            return $this->_view($query, $json_asarray);\n" \
+"            return new CouchbaseResult($this->_view($query, $json_asarray));\n" \
 "        } else if ($query instanceof CouchbaseN1qlQuery) {\n" \
-"            return $this->_n1ql($query, $params, $json_asarray);\n" \
+"            return new CouchbaseResult($this->_n1ql($query, $params, $json_asarray));\n" \
 "        } else {\n" \
 "            throw new CouchbaseException(\n" \
 "                'Passed object must be of type ViewQuery or N1qlQuery');\n" \
@@ -1483,7 +1484,7 @@ pcbc_stub_data PCBC_PHP_CODESTR[] = {
 "                'persist_to' => $options['persist_to'],\n" \
 "                'replicate_to' => $options['replicate_to']\n" \
 "            ));\n" \
-"            \n" \
+"\n" \
 "            return $res;\n" \
 "        }\n" \
 "    }\n" \
@@ -1703,5 +1704,109 @@ pcbc_stub_data PCBC_PHP_CODESTR[] = {
 "        return json_decode($res, true);\n" \
 "    }\n" \
 "} \n" \
+""},
+{"[CouchbaseNative]/CouchbaseResult.class.php","\n" \
+"/**\n" \
+" * File for the CouchbaseResult class.\n" \
+" *\n" \
+" * @author Sylvain Robez-Masson <srm@bouh.org>\n" \
+" */\n" \
+"\n" \
+"/**\n" \
+" * Represents a couchbase result.\n" \
+" *\n" \
+" * Note: This class must be constructed by calling the query\n" \
+" * method of the CouchbaseBucket class.\n" \
+" *\n" \
+" * @property array $rows\n" \
+" * @property integer $offset\n" \
+" *\n" \
+" * @package Couchbase\n" \
+" *\n" \
+" * @see CouchbaseBucket::query()\n" \
+" */\n" \
+"class CouchbaseResult implements Iterator {\n" \
+"\n" \
+"    /**\n" \
+"     * @var array\n" \
+"     * @ignore\n" \
+"     *\n" \
+"     * All the rows of the result.\n" \
+"     */\n" \
+"    private $rows;\n" \
+"\n" \
+"    /**\n" \
+"     * @var integer\n" \
+"     * @ignore\n" \
+"     *\n" \
+"     * Offset of the iterator.\n" \
+"     */\n" \
+"    private $offset;\n" \
+"\n" \
+"    /**\n" \
+"     * Constructs a couchbase result.\n" \
+"     *\n" \
+"     * @private\n" \
+"     * @ignore\n" \
+"     *\n" \
+"     * @param array $rows All the rows returned by a query.\n" \
+"     *\n" \
+"     * @private\n" \
+"     */\n" \
+"    public function __construct(array $rows) {\n" \
+"        $this->rows = $rows;\n" \
+"        $this->offset = 0;\n" \
+"    }\n" \
+"\n" \
+"    /**\n" \
+"     * Retrieve current item of iterator.\n" \
+"     *\n" \
+"     * @return mixed\n" \
+"     */\n" \
+"    public function current()\n" \
+"    {\n" \
+"        return $this->rows[$this->offset];\n" \
+"    }\n" \
+"\n" \
+"    /**\n" \
+"     * Iterator to the next row.\n" \
+"     *\n" \
+"     * @return void\n" \
+"     */\n" \
+"    public function next()\n" \
+"    {\n" \
+"        ++$this->offset;\n" \
+"    }\n" \
+"\n" \
+"    /**\n" \
+"     * Retrieve key of the current row.\n" \
+"     *\n" \
+"     * @return int\n" \
+"     */\n" \
+"    public function key()\n" \
+"    {\n" \
+"        return $this->offset;\n" \
+"    }\n" \
+"\n" \
+"    /**\n" \
+"     * Check if the iterator is still valid.\n" \
+"     *\n" \
+"     * @return bool\n" \
+"     */\n" \
+"    public function valid()\n" \
+"    {\n" \
+"        return isset($this->rows[$this->offset]);\n" \
+"    }\n" \
+"\n" \
+"    /**\n" \
+"     * Rewind iterator\n" \
+"     *\n" \
+"     * @return void\n" \
+"     */\n" \
+"    public function rewind()\n" \
+"    {\n" \
+"        $this->offset = 0;\n" \
+"    }\n" \
+"}\n" \
 ""},
 };

--- a/phpstubstr.h
+++ b/phpstubstr.h
@@ -1354,8 +1354,14 @@ pcbc_stub_data PCBC_PHP_CODESTR[] = {
 "        $path = $queryObj->toString();\n" \
 "        $res = $this->me->http_request(1, 1, $path, NULL, 1);\n" \
 "        $out = json_decode($res, $json_asarray);\n" \
-"        if (isset($out['error'])) {\n" \
-"            throw new CouchbaseException($out['error'] . ': ' . $out['reason']);\n" \
+"        if ($json_asarray) {\n" \
+"            if (isset($out['error'])) {\n" \
+"                throw new CouchbaseException($out['error'] . ': ' . $out['reason']);\n" \
+"            }\n" \
+"        } else {\n" \
+"            if (isset($out->error)) {\n" \
+"                throw new CouchbaseException($out->error . ': ' . $out->reason);\n" \
+"            }\n" \
 "        }\n" \
 "        return $out;\n" \
 "    }\n" \

--- a/stub/CouchbaseBucket.class.php
+++ b/stub/CouchbaseBucket.class.php
@@ -281,8 +281,14 @@ class CouchbaseBucket {
         $path = $queryObj->toString();
         $res = $this->me->http_request(1, 1, $path, NULL, 1);
         $out = json_decode($res, $json_asarray);
-        if (isset($out['error'])) {
-            throw new CouchbaseException($out['error'] . ': ' . $out['reason']);
+        if ($json_asarray) {
+            if (isset($out['error'])) {
+                throw new CouchbaseException($out['error'] . ': ' . $out['reason']);
+            }
+        } else {
+            if (isset($out->error)) {
+                throw new CouchbaseException($out->error . ': ' . $out->reason);
+            }
         }
         return $out;
     }

--- a/stub/CouchbaseBucket.class.php
+++ b/stub/CouchbaseBucket.class.php
@@ -134,6 +134,7 @@ class CouchbaseBucket {
             $this->me->upsert($ids, $val, $options));
     }
 
+
     /**
      * Replaces a document.
      *
@@ -146,7 +147,7 @@ class CouchbaseBucket {
         return $this->_endure($ids, $options,
             $this->me->replace($ids, $val, $options));
     }
-    
+
     /**
      * Appends content to a document.
      *
@@ -159,7 +160,7 @@ class CouchbaseBucket {
         return $this->_endure($ids, $options,
             $this->me->append($ids, $val, $options));
     }
-    
+
     /**
      * Prepends content to a document.
      *
@@ -292,7 +293,7 @@ class CouchbaseBucket {
         }
         return $out;
     }
-    
+
     /**
      * Performs a N1QL query.
      *
@@ -311,7 +312,7 @@ class CouchbaseBucket {
         }
         $dataStr = json_encode($data, true);
         $dataOut = $this->me->n1ql_request($dataStr, $queryObj->adhoc);
-        
+
         $meta = json_decode($dataOut['meta'], true);
         if (isset($meta['errors']) && count($meta['errors']) > 0) {
             $err = $meta['errors'][0];
@@ -319,27 +320,27 @@ class CouchbaseBucket {
             $ex->qCode = $err['code'];
             throw $ex;
         }
-        
+
         $rows = array();
         foreach ($dataOut['results'] as $row) {
             $rows[] = json_decode($row, $json_asarray);
         }
         return $rows;
     }
-    
+
     /**
      * Performs a query (either ViewQuery or N1qlQuery).
      *
      * @param CouchbaseQuery $query
-     * @return mixed
+     * @return CouchbaseResult
      * @throws CouchbaseException
      */
     public function query($query, $params = null, $json_asarray = false) {
         if ($query instanceof _CouchbaseDefaultViewQuery ||
             $query instanceof _CouchbaseSpatialViewQuery) {
-            return $this->_view($query, $json_asarray);
+            return new CouchbaseResult($this->_view($query, $json_asarray));
         } else if ($query instanceof CouchbaseN1qlQuery) {
-            return $this->_n1ql($query, $params, $json_asarray);
+            return new CouchbaseResult($this->_n1ql($query, $params, $json_asarray));
         } else {
             throw new CouchbaseException(
                 'Passed object must be of type ViewQuery or N1qlQuery');
@@ -410,7 +411,7 @@ class CouchbaseBucket {
                 'persist_to' => $options['persist_to'],
                 'replicate_to' => $options['replicate_to']
             ));
-            
+
             return $res;
         }
     }

--- a/stub/CouchbaseResult.class.php
+++ b/stub/CouchbaseResult.class.php
@@ -12,13 +12,14 @@
  * method of the CouchbaseBucket class.
  *
  * @property array $rows
+ * @property int $rowsCount
  * @property integer $offset
  *
  * @package Couchbase
  *
  * @see CouchbaseBucket::query()
  */
-class CouchbaseResult implements Iterator {
+class CouchbaseResult implements Iterator, Countable {
 
     /**
      * @var array
@@ -27,6 +28,14 @@ class CouchbaseResult implements Iterator {
      * All the rows of the result.
      */
     private $rows;
+
+    /**
+     * @var int
+     * @ignore
+     *
+     * Total of rows.
+     */
+    private $rowsCount;
 
     /**
      * @var integer
@@ -43,11 +52,13 @@ class CouchbaseResult implements Iterator {
      * @ignore
      *
      * @param array $rows All the rows returned by a query.
+     * @param int $rowsCount
      *
      * @private
      */
-    public function __construct(array $rows) {
+    public function __construct(array $rows, $rowsCount) {
         $this->rows = $rows;
+        $this->rowsCount = (int) $rowsCount;
         $this->offset = 0;
     }
 
@@ -99,5 +110,15 @@ class CouchbaseResult implements Iterator {
     public function rewind()
     {
         $this->offset = 0;
+    }
+
+    /**
+     * Count elements of an object
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return $this->rowsCount;
     }
 }

--- a/stub/CouchbaseResult.class.php
+++ b/stub/CouchbaseResult.class.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * File for the CouchbaseResult class.
+ *
+ * @author Sylvain Robez-Masson <srm@bouh.org>
+ */
+
+/**
+ * Represents a couchbase result.
+ *
+ * Note: This class must be constructed by calling the query
+ * method of the CouchbaseBucket class.
+ *
+ * @property array $rows
+ * @property integer $offset
+ *
+ * @package Couchbase
+ *
+ * @see CouchbaseBucket::query()
+ */
+class CouchbaseResult implements Iterator {
+
+    /**
+     * @var array
+     * @ignore
+     *
+     * All the rows of the result.
+     */
+    private $rows;
+
+    /**
+     * @var integer
+     * @ignore
+     *
+     * Offset of the iterator.
+     */
+    private $offset;
+
+    /**
+     * Constructs a couchbase result.
+     *
+     * @private
+     * @ignore
+     *
+     * @param array $rows All the rows returned by a query.
+     *
+     * @private
+     */
+    public function __construct(array $rows) {
+        $this->rows = $rows;
+        $this->offset = 0;
+    }
+
+    /**
+     * Retrieve current item of iterator.
+     *
+     * @return mixed
+     */
+    public function current()
+    {
+        return $this->rows[$this->offset];
+    }
+
+    /**
+     * Iterator to the next row.
+     *
+     * @return void
+     */
+    public function next()
+    {
+        ++$this->offset;
+    }
+
+    /**
+     * Retrieve key of the current row.
+     *
+     * @return int
+     */
+    public function key()
+    {
+        return $this->offset;
+    }
+
+    /**
+     * Check if the iterator is still valid.
+     *
+     * @return bool
+     */
+    public function valid()
+    {
+        return isset($this->rows[$this->offset]);
+    }
+
+    /**
+     * Rewind iterator
+     *
+     * @return void
+     */
+    public function rewind()
+    {
+        $this->offset = 0;
+    }
+}

--- a/stub/stub.php
+++ b/stub/stub.php
@@ -16,3 +16,4 @@ require_once('CouchbaseCluster.class.php');
 require_once('CouchbaseClusterManager.class.php');
 require_once('CouchbaseBucket.class.php');
 require_once('CouchbaseBucketManager.class.php');
+require_once('CouchbaseResult.class.php');


### PR DESCRIPTION
Hello,

This feature change the behavior of query to return an Iterator, that a more nice way to return the result and allow code like that : 

``` PHP
foreach ($db->query(CouchbaseN1qlQuery::fromString('SELECT * FROM `beer-sample`')) as $document) {
        var_dump($document);
}
```
